### PR TITLE
Calphy cosmetics

### DIFF
--- a/pyiron_nodes/atomistic/structure/view.py
+++ b/pyiron_nodes/atomistic/structure/view.py
@@ -14,9 +14,8 @@ def Plot3d(
 ):
     """Display atomistic structure (ase.Atoms) using nglview"""
     from structuretoolkit import plot3d
-    from structuretoolkit.build import _repeat
 
-    structure = _repeat(structure, repeat)
+    structure = structure.repeat(repeat)
 
     return plot3d(
         structure=structure,

--- a/pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py
+++ b/pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py
@@ -397,8 +397,8 @@ def PlotFreeEnergy(temperature: np.ndarray, free_energy: np.ndarray):
     figure = plt.show()
     return figure
 
-@as_function_node('phase_transition_temperature')
-def CalcPhaseTransformationTemp(temp_A: np.ndarray, fe_A: np.ndarray, temp_B: np.ndarray, fe_B: np.ndarray, fit_order: int = 4, plot: bool =True) -> float:
+@as_function_node('phase_transition_temperature', 'figure')
+def CalcPhaseTransformationTemp(temp_A: np.ndarray, fe_A: np.ndarray, temp_B: np.ndarray, fe_B: np.ndarray, fit_order: int = 4) -> float:
     """
     Calculate the phase transformation temperature from free energy data.
 
@@ -414,8 +414,6 @@ def CalcPhaseTransformationTemp(temp_A: np.ndarray, fe_A: np.ndarray, temp_B: np
         Free energy array for phase 2.
     fit_order: int
         Order of the polynomial fit.
-    plot: bool
-        Plot the free energy data and the fit.
     
     Returns:
     --------
@@ -460,21 +458,22 @@ def CalcPhaseTransformationTemp(temp_A: np.ndarray, fe_A: np.ndarray, temp_B: np
         warnings.warn('It is likely there is no intersection of free energies')
 
     #plot
-    if plot:
-        c1lo = '#ef9a9a'
-        c1hi = '#b71c1c'
-        c2lo = '#90caf9'
-        c2hi = '#0d47a1'
+    c1lo = '#ef9a9a'
+    c1hi = '#b71c1c'
+    c2lo = '#90caf9'
+    c2hi = '#0d47a1'
 
-        plt.plot(fit_t, fit_f1, color=c1lo, label=f'phase A fit')
-        plt.plot(fit_t, fit_f2, color=c2lo, label=f'phase B fit')
-        plt.plot(temp_A, fe_A, color=c1hi, label='phase A', ls='dashed')
-        plt.plot(temp_B, fe_B, color=c2hi, label='phase B', ls='dashed')
-        plt.axvline(transition_temp, ls='dashed', c='#37474f')
-        plt.ylabel('Free energy (eV/atom)')
-        plt.xlabel('Temperature (K)')
-        plt.legend(frameon=False)
-    return transition_temp
+    plt.plot(fit_t, fit_f1, color=c1lo, label=f'phase A fit')
+    plt.plot(fit_t, fit_f2, color=c2lo, label=f'phase B fit')
+    plt.plot(temp_A, fe_A, color=c1hi, label='phase A', ls='dashed')
+    plt.plot(temp_B, fe_B, color=c2hi, label='phase B', ls='dashed')
+    plt.axvline(transition_temp, ls='dashed', c='#37474f')
+    plt.ylabel('Free energy (eV/atom)')
+    plt.xlabel('Temperature (K)')
+    plt.legend(frameon=False)
+    figure = plt.show()
+
+    return transition_temp, figure
 
 @as_function_node('results')
 def CollectResults() -> pd.DataFrame:

--- a/pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py
+++ b/pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py
@@ -398,7 +398,7 @@ def PlotFreeEnergy(temperature: np.ndarray, free_energy: np.ndarray):
     return figure
 
 @as_function_node('phase_transition_temperature', 'figure')
-def CalcPhaseTransformationTemp(temp_A: np.ndarray, fe_A: np.ndarray, temp_B: np.ndarray, fe_B: np.ndarray, fit_order: int = 4) -> float:
+def CalcPhaseTransformationTemp(temp_A: np.ndarray, fe_A: np.ndarray, temp_B: np.ndarray, fe_B: np.ndarray, fit_order: int = 4):
     """
     Calculate the phase transformation temperature from free energy data.
 


### PR DESCRIPTION
This pull request includes several changes to the `pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py` file and a small change to the `pyiron_nodes/atomistic/structure/view.py` file. The changes focus on improving the handling of potentials, cleaning up the code, and adding new functionalities.

Improvements and new functionalities:

* Added the `ListPotentials` function to list potentials for a given structure.
* Introduced the `_run_cleanup` function to handle the cleanup of simulation folders and lattice files after calculations.
* Added the `PlotFreeEnergy` function to plot free energy against temperature.

Code cleanup and refactoring:

* Removed unused imports and redundant code in the `_prepare_potential_and_structure` function. [[1]](diffhunk://#diff-7757f9a08f4d64bf361c29a2a7ed2143e2d6906312c57fce3fe78fd29f35385dL161-L162) [[2]](diffhunk://#diff-7757f9a08f4d64bf361c29a2a7ed2143e2d6906312c57fce3fe78fd29f35385dL183-R185)
* Refactored the `CalculatePhaseTransformationTemperature` function to improve readability and remove the `plot` parameter, replacing it with the `PlotFreeEnergy` function. [[1]](diffhunk://#diff-7757f9a08f4d64bf361c29a2a7ed2143e2d6906312c57fce3fe78fd29f35385dR386-R430) [[2]](diffhunk://#diff-7757f9a08f4d64bf361c29a2a7ed2143e2d6906312c57fce3fe78fd29f35385dL416-R443) [[3]](diffhunk://#diff-7757f9a08f4d64bf361c29a2a7ed2143e2d6906312c57fce3fe78fd29f35385dL435-R476)

Minor changes:

* Simplified the structure repetition logic in the `Plot3d` function in `pyiron_nodes/atomistic/structure/view.py`.