### PR TITLE
fixes for calphy

### DIFF
--- a/pyiron_nodes/atomistic/structure/transform.py
+++ b/pyiron_nodes/atomistic/structure/transform.py
@@ -27,6 +27,21 @@ def CreateVacancy(structure, index: int | None = 0):
 
     return structure
 
+@as_function_node
+def Rattle(structure, seed: int = 42, stdev: float = 0.1):
+    """
+    Randomly displace the atoms in the structure.
+
+    Parameters:
+
+    seed = 42:
+    Random seed for the random number generator.
+    amplitude = 0.1:
+    The amplitude of the random displacement.
+    """
+    structure = structure.copy()
+    structure.rattle(seed=seed, stdev=stdev)
+    return structure
 
 @as_function_node("structure")
 def RotateAxisAngle(

--- a/pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py
+++ b/pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py
@@ -151,8 +151,8 @@ class InputClass:
     n_switching_steps: int = 2500
     n_print_steps: int = 1000
     n_iterations: int = 1
-    equilibration_control: str = "nose_hoover"
-    melting_cycle: bool = True
+    equilibration_control: str = "nose-hoover"
+    melting_cycle: bool = False
     cores: Optional[int] = 1
 
 def _generate_random_string(length: str) -> str:
@@ -319,7 +319,7 @@ def LiquidFreeEnergy(inp, structure: Atoms, potential: str) -> float:
     return job.report["results"]["free_energy"]
 
 @as_function_node('temperature', 'free_energy')
-def SolidFreeEnergyWithTemperature(inp, structure: Atoms, potential: str) -> Tuple[np.ndarray, np.ndarray]:
+def SolidFreeEnergyWithTemp(inp, structure: Atoms, potential: str) -> Tuple[np.ndarray, np.ndarray]:
     """
     Calculate the free energy of a solid phase as a function of temperature.
 
@@ -354,7 +354,7 @@ def SolidFreeEnergyWithTemperature(inp, structure: Atoms, potential: str) -> Tup
     return t, f
 
 @as_function_node('temperature', 'free_energy')
-def LiquidFreeEnergyWithTemperature(inp, structure: Atoms, potential: str) -> Tuple[np.ndarray, np.ndarray]:
+def LiquidFreeEnergyWithTemp(inp, structure: Atoms, potential: str) -> Tuple[np.ndarray, np.ndarray]:
     """
     Calculate the free energy of a liquid phase as a function of temperature.
 

--- a/pyiron_nodes/experimental/tensile_test/tensile_test.py
+++ b/pyiron_nodes/experimental/tensile_test/tensile_test.py
@@ -2,7 +2,7 @@ from pyiron_workflow import as_function_node, as_macro_node, as_dataclass_node
 import numpy as np
 
 @as_function_node
-def CovertLoadToStress(df, area: float):
+def ConvertLoadToStress(df, area: float):
     """
     Read in csv file, convert load to stress
     """


### PR DESCRIPTION
This pull request includes several changes to the `pyiron_nodes` package, focusing on adding new functionality, correcting parameter values, and renaming functions for clarity. The most important changes are grouped by their themes below:

### New Functionality:
* Added a new `Rattle` function to randomly displace atoms in the structure, with parameters for random seed and displacement amplitude. (`pyiron_nodes/atomistic/structure/transform.py`)

### Parameter Corrections:
* Corrected the `equilibration_control` parameter from "nose_hoover" to "nose-hoover" and set `melting_cycle` to `False` in the `InputClass`. (`pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py`)

### Function Renaming:
* Renamed `SolidFreeEnergyWithTemperature` to `SolidFreeEnergyWithTemp` for consistency. (`pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py`)
* Renamed `LiquidFreeEnergyWithTemperature` to `LiquidFreeEnergyWithTemp` for consistency. (`pyiron_nodes/atomistic/thermodynamics/calphy/calphy.py`)
* Corrected the function name `CovertLoadToStress` to `ConvertLoadToStress`. (`pyiron_nodes/experimental/tensile_test/tensile_test.py`)